### PR TITLE
[Fix] Preserve alpha in HWB and CSS variable output

### DIFF
--- a/src/HwbColor.php
+++ b/src/HwbColor.php
@@ -155,7 +155,15 @@ final readonly class HwbColor extends AbstractColor
             self::normalizeSpaceName($space);
         }
 
-        return \sprintf('hwb(%s %s%% %s%%)', self::formatCssFloat($this->h), self::formatCssFloat($this->w * 100.0), self::formatCssFloat($this->b * 100.0));
+        $h = self::formatCssFloat($this->h);
+        $w = self::formatCssFloat($this->w * 100.0);
+        $b = self::formatCssFloat($this->b * 100.0);
+        if (1.0 === $this->alpha) {
+            return \sprintf('hwb(%s %s%% %s%%)', $h, $w, $b);
+        }
+        $alpha = self::formatCssFloat($this->alpha);
+
+        return \sprintf('hwb(%s %s%% %s%% / %s)', $h, $w, $b, $alpha);
     }
 
     public function toSrgb(): SrgbColor

--- a/src/Palette/ColorPalette.php
+++ b/src/Palette/ColorPalette.php
@@ -354,7 +354,7 @@ final readonly class ColorPalette implements ColorPaletteInterface
         }
         $css = '';
         foreach ($this->colors as $name => $color) {
-            $css .= \sprintf("  --%s-%s: %s;\n", $prefix, $name, $color->toHex());
+            $css .= \sprintf("  --%s-%s: %s;\n", $prefix, $name, $color->toHex(!$color->isOpaque()));
         }
 
         return $css;

--- a/tests/HwbColorTest.php
+++ b/tests/HwbColorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace PhpColor\Color\Tests;
 
+use PhpColor\Color\Color;
 use PhpColor\Color\Exception\InvalidColorException;
 use PhpColor\Color\Exception\ParseException;
 use PhpColor\Color\HwbColor;
@@ -246,6 +247,25 @@ final class HwbColorTest extends TestCase
         $this->assertStringContainsString('200', $cssOklab);
         $this->assertStringContainsString('40%', $cssOklab);
         $this->assertStringContainsString('10%', $cssOklab);
+    }
+
+    public function testToCssOmitsAlphaWhenOpaque(): void
+    {
+        $this->assertSame('hwb(210 20% 30%)', (new HwbColor(210, 0.2, 0.3))->toCss());
+        $this->assertSame('hwb(210 20% 30%)', (new HwbColor(210, 0.2, 0.3, 1.0))->toCss());
+    }
+
+    public function testToCssPreservesAlphaFromConversion(): void
+    {
+        $hwb = Color::parse('rgb(0 0 255 / 0.25)')->to('hwb');
+
+        $this->assertSame('hwb(240 0% 0% / 0.25)', $hwb->toCss());
+    }
+
+    public function testToCssWithAlpha(): void
+    {
+        $this->assertSame('hwb(210 20% 30% / 0.5)', HwbColor::parse('hwb(210 20% 30% / 0.5)')->toCss());
+        $this->assertSame('hwb(90 10% 20% / 0)', (new HwbColor(90, 0.1, 0.2, 0.0))->toCss());
     }
 
     public function testToCssWithExplicitHwbSpace(): void

--- a/tests/Palette/ColorPaletteTest.php
+++ b/tests/Palette/ColorPaletteTest.php
@@ -817,12 +817,29 @@ final class ColorPaletteTest extends TestCase
         $this->assertStringContainsString('--color-test: #ff0000;', $css);
     }
 
+    public function testToCssVariablesKeepsSixDigitsWhenOpaque(): void
+    {
+        $palette = ColorPalette::named(['primary' => Color::parse('rgb(255 0 0 / 1)')]);
+
+        $this->assertSame("  --color-primary: #ff0000;\n", $palette->toCssVariables());
+    }
+
     public function testToCssVariablesScaleThrows(): void
     {
         $palette = ColorPalette::fromHex(['#3b82f6', '#10b981']);
 
         $this->expectException(InvalidColorException::class);
         $palette->toCssVariables();
+    }
+
+    public function testToCssVariablesWithAlpha(): void
+    {
+        $palette = ColorPalette::named([
+            'primary' => Color::parse('#ff0000'),
+            'ghost' => Color::parse('rgb(0 0 255 / 0.25)'),
+        ]);
+
+        $this->assertSame("  --color-primary: #ff0000;\n  --color-ghost: #0000ff40;\n", $palette->toCssVariables());
     }
 
     public function testToCssVariablesWithCustomPrefix(): void


### PR DESCRIPTION
Two places stored alpha correctly but dropped it on output.

Changes

- `src/HwbColor.php`: `toCss()` now emits `hwb(H W% B% / A)` when the color is translucent
- `src/Palette/ColorPalette.php`: `toCssVariables()` calls `toHex(!$color->isOpaque())`

