### PR TITLE
[Fix] Produce valid gradient CSS output

### DIFF
--- a/src/Gradient/AbstractGradient.php
+++ b/src/Gradient/AbstractGradient.php
@@ -15,6 +15,7 @@ namespace PhpColor\Color\Gradient;
 
 use PhpColor\Color\Color;
 use PhpColor\Color\ColorInterface;
+use PhpColor\Color\Exception\InvalidColorException;
 
 /**
  * Abstract base class for gradient implementations.
@@ -31,6 +32,35 @@ abstract readonly class AbstractGradient implements GradientInterface
         protected array $stops = [],
         protected InterpolationSpace $interpolationSpace = InterpolationSpace::Oklab,
     ) {
+    }
+
+    /**
+     * Ensure the gradient can be rendered as CSS.
+     *
+     * @throws InvalidColorException if the gradient has fewer than 2 color stops
+     */
+    protected function assertMinimumStops(): void
+    {
+        $count = \count($this->stops);
+
+        if ($count < 2) {
+            throw new InvalidColorException(\sprintf('A %s gradient requires at least 2 color stops, %d given.', $this->getType(), $count));
+        }
+    }
+
+    /**
+     * Format the interpolation space for CSS output.
+     *
+     * The clause is always emitted: the CSS default is sRGB, which matches
+     * neither of the spaces this library interpolates in. InterpolationSpace::Srgb
+     * mixes linearized channels, so it maps to the CSS srgb-linear space.
+     */
+    protected function formatInterpolationSpace(): string
+    {
+        return match ($this->interpolationSpace) {
+            InterpolationSpace::Oklab => 'in oklab',
+            InterpolationSpace::Srgb => 'in srgb-linear',
+        };
     }
 
     /**

--- a/src/Gradient/ConicGradient.php
+++ b/src/Gradient/ConicGradient.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace PhpColor\Color\Gradient;
 
 use PhpColor\Color\ColorInterface;
+use PhpColor\Color\Exception\InvalidColorException;
+use PhpColor\Color\OklchColor;
 
 /**
  * Conic gradient implementation.
@@ -23,6 +25,16 @@ use PhpColor\Color\ColorInterface;
  */
 final readonly class ConicGradient extends AbstractGradient
 {
+    /**
+     * Chroma of the color wheel hues.
+     */
+    private const float WHEEL_CHROMA = 0.15;
+
+    /**
+     * Lightness of the color wheel hues.
+     */
+    private const float WHEEL_LIGHTNESS = 0.7;
+
     /**
      * Create a new conic gradient instance.
      *
@@ -41,11 +53,29 @@ final readonly class ConicGradient extends AbstractGradient
     }
 
     /**
-     * Create a default color wheel conic gradient.
+     * Create a color wheel conic gradient of evenly spaced OKLCH hues.
+     *
+     * The wheel is closed by repeating the first hue at position 1.0.
+     *
+     * @param int $steps Number of hues around the wheel (at least 2)
+     *
+     * @throws InvalidColorException if fewer than 2 steps are requested
      */
-    public static function colorWheel(): self
+    public static function colorWheel(int $steps = 12): self
     {
-        return new self();
+        if ($steps < 2) {
+            throw new InvalidColorException(\sprintf('A color wheel requires at least 2 steps, %d given.', $steps));
+        }
+
+        $stops = [];
+
+        for ($i = 0; $i < $steps; ++$i) {
+            $stops[] = new GradientStop(new OklchColor(self::WHEEL_LIGHTNESS, self::WHEEL_CHROMA, $i * (360.0 / $steps)), $i / $steps);
+        }
+
+        $stops[] = new GradientStop(new OklchColor(self::WHEEL_LIGHTNESS, self::WHEEL_CHROMA, 0.0), 1.0);
+
+        return new self(stops: $stops);
     }
 
     public function addStop(ColorInterface $color, float $position): static
@@ -79,6 +109,8 @@ final readonly class ConicGradient extends AbstractGradient
 
     public function toCss(?string $colorSpace = null): string
     {
+        $this->assertMinimumStops();
+
         $stopsStr = $this->formatStops($colorSpace);
 
         $params = [];
@@ -91,15 +123,9 @@ final readonly class ConicGradient extends AbstractGradient
             $params[] = 'at '.$this->position;
         }
 
-        $paramsStr = implode(' ', $params);
+        $params[] = $this->formatInterpolationSpace();
 
-        if ([] === $this->stops) {
-            return '' === $paramsStr || '0' === $paramsStr ? 'conic-gradient()' : \sprintf('conic-gradient(%s)', $paramsStr);
-        }
-
-        return '' === $paramsStr || '0' === $paramsStr
-            ? \sprintf('conic-gradient(%s)', $stopsStr)
-            : \sprintf('conic-gradient(%s, %s)', $paramsStr, $stopsStr);
+        return \sprintf('conic-gradient(%s, %s)', implode(' ', $params), $stopsStr);
     }
 
     /**

--- a/src/Gradient/LinearGradient.php
+++ b/src/Gradient/LinearGradient.php
@@ -83,14 +83,14 @@ final readonly class LinearGradient extends AbstractGradient
 
     public function toCss(?string $colorSpace = null): string
     {
-        $angleDeg = round($this->angle, 2);
-        $stopsStr = $this->formatStops($colorSpace);
+        $this->assertMinimumStops();
 
-        if (0 === \count($this->stops)) {
-            return \sprintf('linear-gradient(%sdeg)', $angleDeg);
-        }
+        $params = [
+            \sprintf('%sdeg', round($this->angle, 2)),
+            $this->formatInterpolationSpace(),
+        ];
 
-        return \sprintf('linear-gradient(%sdeg, %s)', $angleDeg, $stopsStr);
+        return \sprintf('linear-gradient(%s, %s)', implode(' ', $params), $this->formatStops($colorSpace));
     }
 
     /**

--- a/src/Gradient/RadialGradient.php
+++ b/src/Gradient/RadialGradient.php
@@ -102,6 +102,8 @@ final readonly class RadialGradient extends AbstractGradient
 
     public function toCss(?string $colorSpace = null): string
     {
+        $this->assertMinimumStops();
+
         $stopsStr = $this->formatStops($colorSpace);
 
         $params = [];
@@ -118,13 +120,9 @@ final readonly class RadialGradient extends AbstractGradient
             $params[] = 'at '.$this->position;
         }
 
-        $paramsStr = implode(' ', $params);
+        $params[] = $this->formatInterpolationSpace();
 
-        if ('' === $paramsStr) {
-            return \sprintf('radial-gradient(%s)', $stopsStr);
-        }
-
-        return \sprintf('radial-gradient(%s%s%s)', $paramsStr, 0 === \count($this->stops) ? '' : ', ', $stopsStr);
+        return \sprintf('radial-gradient(%s, %s)', implode(' ', $params), $stopsStr);
     }
 
     /**

--- a/tests/Gradient/ConicGradientTest.php
+++ b/tests/Gradient/ConicGradientTest.php
@@ -15,8 +15,12 @@ namespace PhpColor\Color\Tests\Gradient;
 
 use PhpColor\Color\Color;
 use PhpColor\Color\ColorInterface;
+use PhpColor\Color\Exception\InvalidColorException;
 use PhpColor\Color\Gradient\ConicGradient;
+use PhpColor\Color\Gradient\GradientStop;
+use PhpColor\Color\Gradient\InterpolationSpace;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(ConicGradient::class)]
@@ -39,6 +43,55 @@ final class ConicGradientTest extends TestCase
         $gradient = ConicGradient::colorWheel();
 
         $this->assertSame(0.0, $gradient->getAngle());
+        $this->assertCount(13, $gradient->getStops());
+    }
+
+    public function testColorWheelClosesOnTheStartingHue(): void
+    {
+        $stops = ConicGradient::colorWheel(6)->getStops();
+        $last = $stops[\count($stops) - 1];
+
+        $this->assertSame(0.0, $stops[0]->position);
+        $this->assertSame(1.0, $last->position);
+        $this->assertEqualsWithDelta($stops[0]->color->to('oklch')->h, $last->color->to('oklch')->h, 1e-9);
+    }
+
+    #[DataProvider('provideColorWheelSteps')]
+    public function testColorWheelStopCount(int $steps): void
+    {
+        $this->assertCount($steps + 1, ConicGradient::colorWheel($steps)->getStops());
+    }
+
+    public static function provideColorWheelSteps(): iterable
+    {
+        yield 'minimum' => [2];
+        yield 'quarters' => [4];
+        yield 'default' => [12];
+        yield 'fine grained' => [36];
+    }
+
+    public function testColorWheelToCss(): void
+    {
+        $this->assertSame(
+            'conic-gradient(in oklab, oklch(0.7 0.15 0) 0%, oklch(0.7 0.15 120) 33.33%, oklch(0.7 0.15 240) 66.67%, oklch(0.7 0.15 0) 100%)',
+            ConicGradient::colorWheel(3)->toCss()
+        );
+    }
+
+    #[DataProvider('provideInvalidColorWheelSteps')]
+    public function testColorWheelRejectsFewerThanTwoSteps(int $steps): void
+    {
+        $this->expectException(InvalidColorException::class);
+        $this->expectExceptionMessage(\sprintf('A color wheel requires at least 2 steps, %d given.', $steps));
+
+        ConicGradient::colorWheel($steps);
+    }
+
+    public static function provideInvalidColorWheelSteps(): iterable
+    {
+        yield 'single step' => [1];
+        yield 'zero steps' => [0];
+        yield 'negative steps' => [-3];
     }
 
     public function testConstructor(): void
@@ -75,17 +128,42 @@ final class ConicGradientTest extends TestCase
         $this->assertStringContainsString('rgb(0 0 255)', $css);
     }
 
-    public function testToCssEmptyReturnsBareFunction(): void
+    public function testToCssWithSrgbInterpolationSpace(): void
+    {
+        $gradient = new ConicGradient(0.0, 'center', [
+            new GradientStop(Color::parse('#ff0000'), 0.0),
+            new GradientStop(Color::parse('#0000ff'), 1.0),
+        ], InterpolationSpace::Srgb);
+
+        $this->assertSame('conic-gradient(in srgb-linear, rgb(255 0 0) 0%, rgb(0 0 255) 100%)', $gradient->toCss());
+    }
+
+    public function testToCssThrowsWithoutStops(): void
     {
         $gradient = new ConicGradient();
-        $css = $gradient->toCss();
-        $this->assertSame('conic-gradient()', $css);
+
+        $this->expectException(InvalidColorException::class);
+        $this->expectExceptionMessage('A conic gradient requires at least 2 color stops, 0 given.');
+
+        $gradient->toCss();
+    }
+
+    public function testToCssThrowsWithSingleStop(): void
+    {
+        $gradient = (new ConicGradient())->addStop(Color::parse('#ff0000'), 0.0);
+
+        $this->expectException(InvalidColorException::class);
+        $this->expectExceptionMessage('A conic gradient requires at least 2 color stops, 1 given.');
+
+        $gradient->toCss();
     }
 
     public function testToCssWithAngle(): void
     {
         $gradient = new ConicGradient(90.0);
-        $gradient = $gradient->addStop(Color::parse('#ff0000'), 0.0);
+        $gradient = $gradient
+            ->addStop(Color::parse('#ff0000'), 0.0)
+            ->addStop(Color::parse('#0000ff'), 1.0);
 
         $css = $gradient->toCss();
 
@@ -96,7 +174,8 @@ final class ConicGradientTest extends TestCase
     {
         $gradient = new ConicGradient(45.0);
         $gradient = $gradient->withPosition('top')
-            ->addStop(Color::parse('#ff0000'), 0.0);
+            ->addStop(Color::parse('#ff0000'), 0.0)
+            ->addStop(Color::parse('#0000ff'), 1.0);
 
         $css = $gradient->toCss();
 
@@ -104,11 +183,22 @@ final class ConicGradientTest extends TestCase
         $this->assertStringContainsString('at top', $css);
     }
 
+    public function testToCssWithOklabInterpolationSpace(): void
+    {
+        $gradient = (new ConicGradient(45.0))
+            ->withPosition('top')
+            ->addStop(Color::parse('#ff0000'), 0.0)
+            ->addStop(Color::parse('#0000ff'), 1.0);
+
+        $this->assertSame('conic-gradient(from 45deg at top in oklab, rgb(255 0 0) 0%, rgb(0 0 255) 100%)', $gradient->toCss());
+    }
+
     public function testToCssWithPosition(): void
     {
         $gradient = new ConicGradient();
         $gradient = $gradient->withPosition('bottom left')
-            ->addStop(Color::parse('#ff0000'), 0.0);
+            ->addStop(Color::parse('#ff0000'), 0.0)
+            ->addStop(Color::parse('#0000ff'), 1.0);
 
         $css = $gradient->toCss();
 

--- a/tests/Gradient/GradientBuilderTest.php
+++ b/tests/Gradient/GradientBuilderTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace PhpColor\Color\Tests\Gradient;
 
 use PhpColor\Color\Color;
+use PhpColor\Color\Exception\InvalidColorException;
 use PhpColor\Color\Gradient\ConicGradient;
 use PhpColor\Color\Gradient\Gradient;
 use PhpColor\Color\Gradient\GradientBuilder;
@@ -28,6 +29,51 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(Gradient::class)]
 final class GradientBuilderTest extends TestCase
 {
+    public function testBuiltGradientEmitsInterpolationSpace(): void
+    {
+        $css = GradientBuilder::linear(90.0)
+            ->from('#ff0000')
+            ->to('#0000ff')
+            ->build()
+            ->toCss();
+
+        $this->assertSame('linear-gradient(90deg in oklab, rgb(255 0 0) 0%, rgb(0 0 255) 100%)', $css);
+    }
+
+    public function testBuiltGradientEmitsSrgbInterpolationSpaceAsLinear(): void
+    {
+        $css = GradientBuilder::linear(90.0)
+            ->from('#ff0000')
+            ->to('#0000ff')
+            ->in('srgb')
+            ->build()
+            ->toCss();
+
+        $this->assertSame('linear-gradient(90deg in srgb-linear, rgb(255 0 0) 0%, rgb(0 0 255) 100%)', $css);
+    }
+
+    public function testEmptyBuiltGradientBuildsButFailsToRender(): void
+    {
+        $gradient = GradientBuilder::linear()->build();
+
+        $this->assertSame([], $gradient->getStops());
+
+        $this->expectException(InvalidColorException::class);
+        $this->expectExceptionMessage('A linear gradient requires at least 2 color stops, 0 given.');
+
+        $gradient->toCss();
+    }
+
+    public function testSingleStopBuiltGradientFailsToRender(): void
+    {
+        $gradient = GradientBuilder::radial()->from('#ff0000')->build();
+
+        $this->expectException(InvalidColorException::class);
+        $this->expectExceptionMessage('A radial gradient requires at least 2 color stops, 1 given.');
+
+        $gradient->toCss();
+    }
+
     public function testBuilderInterpolationSpace(): void
     {
         $gradient = GradientBuilder::linear()

--- a/tests/Gradient/LinearGradientTest.php
+++ b/tests/Gradient/LinearGradientTest.php
@@ -15,6 +15,9 @@ namespace PhpColor\Color\Tests\Gradient;
 
 use PhpColor\Color\Color;
 use PhpColor\Color\ColorInterface;
+use PhpColor\Color\Exception\InvalidColorException;
+use PhpColor\Color\Gradient\GradientStop;
+use PhpColor\Color\Gradient\InterpolationSpace;
 use PhpColor\Color\Gradient\LinearGradient;
 use PhpColor\Color\SrgbColor;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -140,13 +143,43 @@ final class LinearGradientTest extends TestCase
         $this->assertEqualsWithDelta(1.0, $rgb->r, 0.01);
     }
 
-    public function testToCssEmpty(): void
+    public function testToCssWithSrgbInterpolationSpace(): void
+    {
+        $gradient = new LinearGradient(90.0, [
+            new GradientStop(Color::parse('#ff0000'), 0.0),
+            new GradientStop(Color::parse('#0000ff'), 1.0),
+        ], InterpolationSpace::Srgb);
+
+        $this->assertSame('linear-gradient(90deg in srgb-linear, rgb(255 0 0) 0%, rgb(0 0 255) 100%)', $gradient->toCss());
+    }
+
+    public function testToCssThrowsWithoutStops(): void
     {
         $gradient = new LinearGradient(90.0);
-        $css = $gradient->toCss();
 
-        $this->assertStringStartsWith('linear-gradient(', $css);
-        $this->assertStringContainsString('90deg', $css);
+        $this->expectException(InvalidColorException::class);
+        $this->expectExceptionMessage('A linear gradient requires at least 2 color stops, 0 given.');
+
+        $gradient->toCss();
+    }
+
+    public function testToCssThrowsWithSingleStop(): void
+    {
+        $gradient = (new LinearGradient())->addStop(Color::parse('#ff0000'), 0.0);
+
+        $this->expectException(InvalidColorException::class);
+        $this->expectExceptionMessage('A linear gradient requires at least 2 color stops, 1 given.');
+
+        $gradient->toCss();
+    }
+
+    public function testToCssWithOklabInterpolationSpace(): void
+    {
+        $gradient = (new LinearGradient())
+            ->addStop(Color::parse('#ff0000'), 0.0)
+            ->addStop(Color::parse('#0000ff'), 1.0);
+
+        $this->assertSame('linear-gradient(180deg in oklab, rgb(255 0 0) 0%, rgb(0 0 255) 100%)', $gradient->toCss());
     }
 
     public function testToCssWithStops(): void

--- a/tests/Gradient/RadialGradientTest.php
+++ b/tests/Gradient/RadialGradientTest.php
@@ -15,6 +15,9 @@ namespace PhpColor\Color\Tests\Gradient;
 
 use PhpColor\Color\Color;
 use PhpColor\Color\ColorInterface;
+use PhpColor\Color\Exception\InvalidColorException;
+use PhpColor\Color\Gradient\GradientStop;
+use PhpColor\Color\Gradient\InterpolationSpace;
 use PhpColor\Color\Gradient\RadialGradient;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -94,11 +97,51 @@ final class RadialGradientTest extends TestCase
         $this->assertStringContainsString('circle', $css);
     }
 
+    public function testToCssWithSrgbInterpolationSpace(): void
+    {
+        $gradient = new RadialGradient('ellipse', 'farthest-corner', 'center', [
+            new GradientStop(Color::parse('#ff0000'), 0.0),
+            new GradientStop(Color::parse('#0000ff'), 1.0),
+        ], InterpolationSpace::Srgb);
+
+        $this->assertSame('radial-gradient(in srgb-linear, rgb(255 0 0) 0%, rgb(0 0 255) 100%)', $gradient->toCss());
+    }
+
+    public function testToCssThrowsWithoutStops(): void
+    {
+        $gradient = new RadialGradient();
+
+        $this->expectException(InvalidColorException::class);
+        $this->expectExceptionMessage('A radial gradient requires at least 2 color stops, 0 given.');
+
+        $gradient->toCss();
+    }
+
+    public function testToCssThrowsWithSingleStop(): void
+    {
+        $gradient = (new RadialGradient())->addStop(Color::parse('#ff0000'), 0.0);
+
+        $this->expectException(InvalidColorException::class);
+        $this->expectExceptionMessage('A radial gradient requires at least 2 color stops, 1 given.');
+
+        $gradient->toCss();
+    }
+
+    public function testToCssWithOklabInterpolationSpace(): void
+    {
+        $gradient = RadialGradient::circle()
+            ->addStop(Color::parse('#ff0000'), 0.0)
+            ->addStop(Color::parse('#0000ff'), 1.0);
+
+        $this->assertSame('radial-gradient(circle in oklab, rgb(255 0 0) 0%, rgb(0 0 255) 100%)', $gradient->toCss());
+    }
+
     public function testToCssWithPosition(): void
     {
         $gradient = new RadialGradient();
         $gradient = $gradient->withPosition('top left')
-            ->addStop(Color::parse('#ff0000'), 0.0);
+            ->addStop(Color::parse('#ff0000'), 0.0)
+            ->addStop(Color::parse('#0000ff'), 1.0);
 
         $css = $gradient->toCss();
 
@@ -109,7 +152,8 @@ final class RadialGradientTest extends TestCase
     {
         $gradient = new RadialGradient();
         $gradient = $gradient->withSize('closest-side')
-            ->addStop(Color::parse('#ff0000'), 0.0);
+            ->addStop(Color::parse('#ff0000'), 0.0)
+            ->addStop(Color::parse('#0000ff'), 1.0);
 
         $css = $gradient->toCss();
 


### PR DESCRIPTION
Three defects in gradient CSS: the interpolation space was never emitted, degenerate gradients produced invalid CSS, and `colorWheel()` returned an empty gradient.

## Changes

- `src/Gradient/AbstractGradient.php`: add `formatInterpolationSpace()` and `assertMinimumStops()`.
- `src/Gradient/LinearGradient.php`, `RadialGradient.php`, `ConicGradient.php`: emit the interpolation clause, throw below 2 stops.
- `src/Gradient/ConicGradient.php`: `colorWheel(int $steps = 12)` builds evenly spaced OKLCH hues at `l = 0.7`, `c = 0.15`, closed by repeating hue 0 at position 1.