### PR TITLE
[Fix] Preserve explicit gradient stop positions

### DIFF
--- a/src/Gradient/Gradient.php
+++ b/src/Gradient/Gradient.php
@@ -99,55 +99,88 @@ final class Gradient
     }
 
     /**
-     * Auto-distribute color stops evenly across the gradient.
+     * Resolve the positions of stops that were given without one.
      *
-     * @param list<GradientStop> $stops
+     * Explicit positions are kept as-is. Stops without a position are spread evenly between the
+     * surrounding explicit positions: from 0 before the first explicit position, up to 1 after the
+     * last one, and evenly across the whole gradient when no position is explicit at all.
      *
-     * @return list<GradientStop>
+     * @internal
+     *
+     * @param list<float|null> $positions Explicit positions, null where the caller gave none
+     *
+     * @return list<float>
      */
-    private static function distributeStops(array $stops): array
+    public static function distributePositions(array $positions): array
     {
-        $count = \count($stops);
-        if ($count <= 1) {
-            return $stops;
+        $count = \count($positions);
+        $resolved = [];
+        $index = 0;
+
+        while ($index < $count) {
+            $position = $positions[$index];
+            if (null !== $position) {
+                $resolved[] = $position;
+                ++$index;
+
+                continue;
+            }
+
+            $last = $index;
+            while ($last + 1 < $count && null === $positions[$last + 1]) {
+                ++$last;
+            }
+
+            $before = $index > 0 ? $positions[$index - 1] : null;
+            $after = $last + 1 < $count ? $positions[$last + 1] : null;
+            $length = $last - $index + 1;
+
+            for ($i = 0; $i < $length; ++$i) {
+                if (null !== $before && null !== $after) {
+                    $resolved[] = $before + ($after - $before) * ($i + 1) / ($length + 1);
+                } elseif (null !== $after) {
+                    $resolved[] = $after * $i / $length;
+                } elseif (null !== $before) {
+                    $resolved[] = $before + (1.0 - $before) * ($i + 1) / $length;
+                } else {
+                    $resolved[] = $length > 1 ? (float) $i / ($length - 1) : 0.0;
+                }
+            }
+
+            $index = $last + 1;
         }
 
-        $distributed = [];
-        $den = $count - 1;
-        foreach ($stops as $i => $stop) {
-            $position = $i / $den;
-            $distributed[] = new GradientStop($stop->color, $position);
-        }
-
-        return $distributed;
+        return $resolved;
     }
 
     /**
      * Normalize stops to GradientStop objects.
      *
-     * Converts colors/strings to GradientStop objects and auto-distributes positions if needed.
+     * Converts colors/strings to GradientStop objects, keeping the positions carried by the
+     * GradientStop arguments and distributing the others around them.
      *
      * @return list<GradientStop>
      */
     private static function normalizeStops(ColorInterface|GradientStop|string ...$stops): array
     {
-        $gradientStops = [];
-        $needsDistribution = false;
+        $colors = [];
+        $positions = [];
 
         foreach ($stops as $stop) {
             if ($stop instanceof GradientStop) {
-                $gradientStops[] = $stop;
+                $colors[] = $stop->color;
+                $positions[] = $stop->position;
             } else {
-                $color = \is_string($stop) ? Color::parse($stop) : $stop;
-                $gradientStops[] = new GradientStop($color, 0.0);
-                $needsDistribution = true;
+                $colors[] = \is_string($stop) ? Color::parse($stop) : $stop;
+                $positions[] = null;
             }
         }
 
-        if (!$needsDistribution) {
-            return $gradientStops;
+        $gradientStops = [];
+        foreach (self::distributePositions($positions) as $i => $position) {
+            $gradientStops[] = new GradientStop($colors[$i], $position);
         }
 
-        return self::distributeStops($gradientStops);
+        return $gradientStops;
     }
 }

--- a/src/Gradient/GradientBuilder.php
+++ b/src/Gradient/GradientBuilder.php
@@ -197,30 +197,34 @@ final class GradientBuilder
     /**
      * Add multiple color stops with automatic position distribution.
      *
-     * Accepts colors, color strings, or GradientStop objects. If positions are not specified
-     * (i.e., colors/strings), they will be auto-distributed evenly across the gradient.
+     * Accepts colors, color strings, or GradientStop objects. GradientStop objects keep their
+     * position, while colors/strings are spread evenly between the surrounding positions.
      *
      * @param ColorInterface|GradientStop|string ...$stops Color stops to add
      */
     public function stops(ColorInterface|GradientStop|string ...$stops): self
     {
-        $colorOnlyStops = [];
+        $colors = [];
+        $positions = [];
+
+        foreach ($this->stops as $stop) {
+            $colors[] = $stop->color;
+            $positions[] = $stop->position;
+        }
 
         foreach ($stops as $stop) {
             if ($stop instanceof GradientStop) {
-                $this->stops[] = $stop;
+                $colors[] = $stop->color;
+                $positions[] = $stop->position;
             } else {
-                $color = \is_string($stop) ? Color::parse($stop) : $stop;
-                $colorOnlyStops[] = $color;
+                $colors[] = \is_string($stop) ? Color::parse($stop) : $stop;
+                $positions[] = null;
             }
         }
 
-        if ([] !== $colorOnlyStops) {
-            $count = \count($colorOnlyStops);
-            foreach ($colorOnlyStops as $i => $color) {
-                $position = $count > 1 ? $i / ($count - 1) : 0.5;
-                $this->stops[] = new GradientStop($color, $position);
-            }
+        $this->stops = [];
+        foreach (Gradient::distributePositions($positions) as $i => $position) {
+            $this->stops[] = new GradientStop($colors[$i], $position);
         }
 
         return $this;

--- a/tests/Gradient/GradientBuilderTest.php
+++ b/tests/Gradient/GradientBuilderTest.php
@@ -107,6 +107,91 @@ final class GradientBuilderTest extends TestCase
         $stops = $gradient->getStops();
         $this->assertCount(2, $stops);
         $this->assertEqualsWithDelta(0.25, $stops[0]->position, 1e-12);
+        $this->assertEqualsWithDelta(1.0, $stops[1]->position, 1e-12);
+    }
+
+    public function testBuilderStopsKeepsExplicitPositionMixedWithPlainColor(): void
+    {
+        $gradient = GradientBuilder::linear(180.0)
+            ->stops('#000000', new GradientStop(Color::parse('#ff0000'), 0.9))
+            ->build();
+
+        $stops = $gradient->getStops();
+        $this->assertCount(2, $stops);
+        $this->assertEqualsWithDelta(0.0, $stops[0]->position, 1e-12);
+        $this->assertEqualsWithDelta(0.9, $stops[1]->position, 1e-12);
+        $this->assertStringContainsString('rgb(255 0 0) 90%', $gradient->toCss());
+    }
+
+    public function testBuilderStopsSpreadsPlainColorBetweenExplicitStops(): void
+    {
+        $gradient = GradientBuilder::linear()
+            ->stops(
+                new GradientStop(Color::parse('#ff0000'), 0.2),
+                '#000000',
+                new GradientStop(Color::parse('#00ff00'), 0.8),
+            )
+            ->build();
+
+        $stops = $gradient->getStops();
+        $this->assertCount(3, $stops);
+        $this->assertEqualsWithDelta(0.2, $stops[0]->position, 1e-12);
+        $this->assertEqualsWithDelta(0.5, $stops[1]->position, 1e-12);
+        $this->assertEqualsWithDelta(0.8, $stops[2]->position, 1e-12);
+    }
+
+    public function testBuilderStopsWithOnlyExplicitStopsKeepsEveryPosition(): void
+    {
+        $gradient = GradientBuilder::linear()
+            ->stops(
+                new GradientStop(Color::parse('#ff0000'), 0.3),
+                new GradientStop(Color::parse('#00ff00'), 0.7),
+            )
+            ->build();
+
+        $stops = $gradient->getStops();
+        $this->assertCount(2, $stops);
+        $this->assertEqualsWithDelta(0.3, $stops[0]->position, 1e-12);
+        $this->assertEqualsWithDelta(0.7, $stops[1]->position, 1e-12);
+    }
+
+    public function testBuilderStopsWithSingleColorStartsAtZero(): void
+    {
+        $gradient = GradientBuilder::linear()->stops('#ff0000')->build();
+
+        $stops = $gradient->getStops();
+        $this->assertCount(1, $stops);
+        $this->assertEqualsWithDelta(0.0, $stops[0]->position, 1e-12);
+    }
+
+    public function testBuilderStopsSpreadsAfterAlreadyAddedStops(): void
+    {
+        $gradient = GradientBuilder::linear()->from('#000000')->stops('#888888', '#ffffff')->build();
+
+        $stops = $gradient->getStops();
+        $this->assertCount(3, $stops);
+        $this->assertEqualsWithDelta(0.0, $stops[0]->position, 1e-12);
+        $this->assertEqualsWithDelta(0.5, $stops[1]->position, 1e-12);
+        $this->assertEqualsWithDelta(1.0, $stops[2]->position, 1e-12);
+    }
+
+    public function testBuilderStopsMatchesFacadeForMixedStops(): void
+    {
+        $arguments = [
+            '#000000',
+            new GradientStop(Color::parse('#ff0000'), 0.2),
+            '#888888',
+            new GradientStop(Color::parse('#00ff00'), 0.8),
+            '#ffffff',
+        ];
+
+        $built = GradientBuilder::linear(180.0)->stops(...$arguments)->build();
+        $direct = Gradient::linear(180.0, ...$arguments);
+
+        $this->assertSame(
+            array_column($direct->getStops(), 'position'),
+            array_column($built->getStops(), 'position'),
+        );
     }
 
     public function testBuilderStopsMethod(): void

--- a/tests/Gradient/GradientFacadeTest.php
+++ b/tests/Gradient/GradientFacadeTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace PhpColor\Color\Tests\Gradient;
 
+use PhpColor\Color\Color;
 use PhpColor\Color\Gradient\ConicGradient;
 use PhpColor\Color\Gradient\Gradient;
 use PhpColor\Color\Gradient\GradientBuilder;
@@ -56,19 +57,108 @@ final class GradientFacadeTest extends TestCase
     public function testLinearWithMixedStopTypes(): void
     {
         $red = new SrgbColor(1.0, 0.0, 0.0);
-        // Use an explicit position that is NOT where it would be auto-distributed
-        // to properly test that it gets overridden.
+        // Explicit position that differs from where an even distribution would put it.
         $explicitStop = new GradientStop(new SrgbColor(0.0, 1.0, 0.0), 0.4);
 
         $g = Gradient::linear(90.0, $red, $explicitStop, '#0000ff');
         $stops = $g->getStops();
 
-        // When mixing implicit and explicit stops, all stops are evenly re-distributed,
-        // and pre-existing explicit positions are discarded.
         $this->assertCount(3, $stops);
-        $this->assertEqualsWithDelta(0.0, $stops[0]->position, 1e-12); // Was implicit, becomes 0.0
-        $this->assertEqualsWithDelta(0.5, $stops[1]->position, 1e-12); // Was explicit 0.4, becomes 0.5
-        $this->assertEqualsWithDelta(1.0, $stops[2]->position, 1e-12); // Was implicit, becomes 1.0
+        $this->assertEqualsWithDelta(0.0, $stops[0]->position, 1e-12);
+        $this->assertEqualsWithDelta(0.4, $stops[1]->position, 1e-12);
+        $this->assertEqualsWithDelta(1.0, $stops[2]->position, 1e-12);
+    }
+
+    public function testLinearKeepsExplicitPositionMixedWithPlainColor(): void
+    {
+        $g = Gradient::linear(180.0, '#000000', new GradientStop(Color::parse('#ff0000'), 0.9));
+        $stops = $g->getStops();
+
+        $this->assertCount(2, $stops);
+        $this->assertEqualsWithDelta(0.0, $stops[0]->position, 1e-12);
+        $this->assertEqualsWithDelta(0.9, $stops[1]->position, 1e-12);
+        $this->assertStringContainsString('rgb(255 0 0) 90%', $g->toCss());
+    }
+
+    public function testLinearSpreadsPlainColorBetweenExplicitStops(): void
+    {
+        $g = Gradient::linear(
+            180.0,
+            new GradientStop(Color::parse('#ff0000'), 0.2),
+            '#000000',
+            new GradientStop(Color::parse('#00ff00'), 0.8),
+        );
+        $stops = $g->getStops();
+
+        $this->assertCount(3, $stops);
+        $this->assertEqualsWithDelta(0.2, $stops[0]->position, 1e-12);
+        $this->assertEqualsWithDelta(0.5, $stops[1]->position, 1e-12);
+        $this->assertEqualsWithDelta(0.8, $stops[2]->position, 1e-12);
+    }
+
+    public function testLinearSpreadsConsecutivePlainColorsBetweenExplicitStops(): void
+    {
+        $g = Gradient::linear(
+            180.0,
+            new GradientStop(Color::parse('#ff0000'), 0.2),
+            '#000000',
+            '#888888',
+            new GradientStop(Color::parse('#00ff00'), 0.8),
+        );
+        $stops = $g->getStops();
+
+        $this->assertCount(4, $stops);
+        $this->assertEqualsWithDelta(0.2, $stops[0]->position, 1e-12);
+        $this->assertEqualsWithDelta(0.4, $stops[1]->position, 1e-12);
+        $this->assertEqualsWithDelta(0.6, $stops[2]->position, 1e-12);
+        $this->assertEqualsWithDelta(0.8, $stops[3]->position, 1e-12);
+    }
+
+    public function testLinearSpreadsLeadingPlainColorsFromZero(): void
+    {
+        $g = Gradient::linear(180.0, '#000000', '#888888', new GradientStop(Color::parse('#00ff00'), 0.9));
+        $stops = $g->getStops();
+
+        $this->assertCount(3, $stops);
+        $this->assertEqualsWithDelta(0.0, $stops[0]->position, 1e-12);
+        $this->assertEqualsWithDelta(0.45, $stops[1]->position, 1e-12);
+        $this->assertEqualsWithDelta(0.9, $stops[2]->position, 1e-12);
+    }
+
+    public function testLinearSpreadsTrailingPlainColorsUpToOne(): void
+    {
+        $g = Gradient::linear(180.0, new GradientStop(Color::parse('#ff0000'), 0.1), '#000000', '#888888');
+        $stops = $g->getStops();
+
+        $this->assertCount(3, $stops);
+        $this->assertEqualsWithDelta(0.1, $stops[0]->position, 1e-12);
+        $this->assertEqualsWithDelta(0.55, $stops[1]->position, 1e-12);
+        $this->assertEqualsWithDelta(1.0, $stops[2]->position, 1e-12);
+    }
+
+    public function testLinearWithoutExplicitPositionDistributesEvenly(): void
+    {
+        $g = Gradient::linear(180.0, '#000000', '#888888', '#ffffff');
+        $stops = $g->getStops();
+
+        $this->assertCount(3, $stops);
+        $this->assertEqualsWithDelta(0.0, $stops[0]->position, 1e-12);
+        $this->assertEqualsWithDelta(0.5, $stops[1]->position, 1e-12);
+        $this->assertEqualsWithDelta(1.0, $stops[2]->position, 1e-12);
+    }
+
+    public function testLinearWithOnlyExplicitStopsKeepsEveryPosition(): void
+    {
+        $g = Gradient::linear(
+            180.0,
+            new GradientStop(Color::parse('#ff0000'), 0.3),
+            new GradientStop(Color::parse('#00ff00'), 0.7),
+        );
+        $stops = $g->getStops();
+
+        $this->assertCount(2, $stops);
+        $this->assertEqualsWithDelta(0.3, $stops[0]->position, 1e-12);
+        $this->assertEqualsWithDelta(0.7, $stops[1]->position, 1e-12);
     }
 
     public function testConicWithNullValuesFilteredOut(): void


### PR DESCRIPTION
Passing one plain color alongside positioned stops reset every position, including the ones the caller set.

Changes

- `src/Gradient/Gradient.php`: `distributeStops()` becomes `distributePositions()`. Explicit positions are kept, unpositioned stops spread between their explicit neighbours.
- `src/Gradient/GradientBuilder.php`: `stops()` delegates to the same method instead of distributing plain colors on its own.
