### PR TITLE
[Fix] Extend Throwable in ColorExceptionInterface

### DIFF
--- a/src/Exception/ColorExceptionInterface.php
+++ b/src/Exception/ColorExceptionInterface.php
@@ -16,6 +16,6 @@ namespace PhpColor\Color\Exception;
 /**
  * Common interface for all exceptions thrown by the PHPColor library.
  */
-interface ColorExceptionInterface
+interface ColorExceptionInterface extends \Throwable
 {
 }

--- a/tests/Exception/ExceptionsCoveredTest.php
+++ b/tests/Exception/ExceptionsCoveredTest.php
@@ -13,8 +13,12 @@ declare(strict_types=1);
 
 namespace PhpColor\Color\Tests\Exception;
 
+use PhpColor\Color\Exception\ColorExceptionInterface;
+use PhpColor\Color\Exception\InvalidArgumentException;
 use PhpColor\Color\Exception\InvalidColorException;
+use PhpColor\Color\Exception\InvalidColorSpaceException;
 use PhpColor\Color\Exception\ParseException;
+use PhpColor\Color\Exception\UnsupportedColorSpaceException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -32,5 +36,37 @@ final class ExceptionsCoveredTest extends TestCase
     {
         $e = new ParseException('bad');
         $this->assertSame('bad', $e->getMessage());
+    }
+
+    public function testEveryLibraryExceptionIsCatchableThroughTheInterface(): void
+    {
+        $exceptions = [
+            new InvalidArgumentException('a'),
+            new InvalidColorException('b'),
+            new InvalidColorSpaceException('c'),
+            new ParseException('d'),
+            new UnsupportedColorSpaceException('e'),
+        ];
+
+        foreach ($exceptions as $exception) {
+            $this->assertInstanceOf(ColorExceptionInterface::class, $exception);
+            $this->assertInstanceOf(\Throwable::class, $exception);
+        }
+    }
+
+    public function testInterfaceExtendsThrowable(): void
+    {
+        $this->assertTrue(is_a(ColorExceptionInterface::class, \Throwable::class, true));
+    }
+
+    public function testInterfaceExposesThrowableApi(): void
+    {
+        try {
+            throw new ParseException('boom');
+        } catch (ColorExceptionInterface $e) {
+            $this->assertSame('boom', $e->getMessage());
+            $this->assertSame(0, $e->getCode());
+            $this->assertNotSame('', $e->getFile());
+        }
     }
 }


### PR DESCRIPTION
`ColorExceptionInterface` did not extend `Throwable`, so catching it gave no access to `getMessage()` under static analysis.

Changes:
- `src/Exception/ColorExceptionInterface.php`: `interface ColorExceptionInterface extends \Throwable`.

Catching worked at runtime because all five concrete classes extend `Exception`, but the interface guaranteed nothing.
