### PR TITLE
[Fix] Allow choosing the closest() distance metric

### DIFF
--- a/src/Palette/ColorPalette.php
+++ b/src/Palette/ColorPalette.php
@@ -15,6 +15,7 @@ namespace PhpColor\Color\Palette;
 
 use PhpColor\Color\Color;
 use PhpColor\Color\ColorInterface;
+use PhpColor\Color\Distance\ColorDistanceInterface;
 use PhpColor\Color\Exception\InvalidColorException;
 use PhpColor\Color\OklabColor;
 use PhpColor\Color\OklchColor;
@@ -204,7 +205,7 @@ final readonly class ColorPalette implements ColorPaletteInterface
         return Color::mix($colors[$index], $colors[$index + 1], $fraction, 'oklab');
     }
 
-    public function closest(ColorInterface $target): ColorInterface
+    public function closest(ColorInterface $target, ?ColorDistanceInterface $metric = null): ColorInterface
     {
         if ([] === $this->colors) {
             throw new InvalidColorException('Cannot find closest color in empty palette.');
@@ -216,11 +217,7 @@ final readonly class ColorPalette implements ColorPaletteInterface
         $minDistance = \PHP_FLOAT_MAX;
         $closest = array_values($this->colors)[0];
         foreach ($this->colors as $color) {
-            $oklab = $color->to('oklab');
-            if (!$oklab instanceof OklabColor) {
-                $oklab = OklabColor::fromSrgb($oklab->toSrgb());
-            }
-            $distance = sqrt(($targetOklab->l - $oklab->l) ** 2 + ($targetOklab->a - $oklab->a) ** 2 + ($targetOklab->b - $oklab->b) ** 2);
+            $distance = $metric?->calculate($target, $color) ?? self::oklabDistance($targetOklab, $color);
             if ($distance < $minDistance) {
                 $minDistance = $distance;
                 $closest = $color;
@@ -368,5 +365,18 @@ final readonly class ColorPalette implements ColorPaletteInterface
         }
 
         return $result;
+    }
+
+    /**
+     * Default metric of closest(): Euclidean distance in the Oklab color space.
+     */
+    private static function oklabDistance(OklabColor $target, ColorInterface $color): float
+    {
+        $oklab = $color->to('oklab');
+        if (!$oklab instanceof OklabColor) {
+            $oklab = OklabColor::fromSrgb($oklab->toSrgb());
+        }
+
+        return sqrt(($target->l - $oklab->l) ** 2 + ($target->a - $oklab->a) ** 2 + ($target->b - $oklab->b) ** 2);
     }
 }

--- a/src/Palette/ColorPaletteInterface.php
+++ b/src/Palette/ColorPaletteInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace PhpColor\Color\Palette;
 
 use PhpColor\Color\ColorInterface;
+use PhpColor\Color\Distance\ColorDistanceInterface;
 use PhpColor\Color\Exception\InvalidColorException;
 
 /**
@@ -46,11 +47,15 @@ interface ColorPaletteInterface extends \Countable, \IteratorAggregate
     /**
      * Find the color in the palette that is closest to a target color.
      *
-     * Uses perceptual color distance (CIEDE2000) to find the best match.
+     * By default, the match is the one with the smallest Euclidean distance in
+     * the Oklab color space.
+     *
+     * @param ColorDistanceInterface|null $metric Distance algorithm to compare colors with,
+     *                                            or null for the default Oklab Euclidean distance
      *
      * @throws InvalidColorException If the palette is empty
      */
-    public function closest(ColorInterface $color): ColorInterface;
+    public function closest(ColorInterface $color, ?ColorDistanceInterface $metric = null): ColorInterface;
 
     /**
      * Get the number of colors in the palette.

--- a/tests/Palette/ColorPaletteTest.php
+++ b/tests/Palette/ColorPaletteTest.php
@@ -16,6 +16,7 @@ namespace PhpColor\Color\Tests\Palette;
 use PhpColor\Color\AbstractColor;
 use PhpColor\Color\Color;
 use PhpColor\Color\ColorInterface;
+use PhpColor\Color\Distance\Ciede2000;
 use PhpColor\Color\Exception\InvalidColorException;
 use PhpColor\Color\OklchColor;
 use PhpColor\Color\Palette\ColorPalette;
@@ -189,6 +190,17 @@ final class ColorPaletteTest extends TestCase
         $this->assertInstanceOf(ColorInterface::class, $closest);
     }
 
+    public function testClosestDefaultsToOklabEuclideanDistance(): void
+    {
+        $palette = ColorPalette::fromHex(['#000000', '#404040', '#808080', '#c0c0c0', '#ffffff', '#00007f', '#7f0000', '#007f00']);
+
+        $this->assertSame('#404040', $palette->closest(Color::parse('#002233'))->toHex());
+        $this->assertSame('#808080', $palette->closest(Color::parse('#fe0000'))->toHex());
+        $this->assertSame('#c0c0c0', $palette->closest(Color::parse('#00ff00'))->toHex());
+        $this->assertSame('#404040', $palette->closest(Color::parse('#123456'))->toHex());
+        $this->assertSame('#ffffff', $palette->closest(Color::parse('#eeeeee'))->toHex());
+    }
+
     public function testClosestEmptyThrows(): void
     {
         $palette = ColorPalette::scale([Color::parse('#ff0000')]);
@@ -196,6 +208,25 @@ final class ColorPaletteTest extends TestCase
 
         $this->expectException(InvalidColorException::class);
         $filtered->closest(Color::parse('#000000'));
+    }
+
+    public function testClosestEmptyWithMetricThrows(): void
+    {
+        $palette = ColorPalette::scale([Color::parse('#ff0000')]);
+        $filtered = $palette->filter(static fn (): false => false);
+
+        $this->expectException(InvalidColorException::class);
+        $filtered->closest(Color::parse('#000000'), new Ciede2000());
+    }
+
+    public function testClosestWithCiede2000Metric(): void
+    {
+        $palette = ColorPalette::fromHex(['#000000', '#404040', '#808080', '#c0c0c0', '#ffffff', '#00007f', '#7f0000', '#007f00']);
+        $target = Color::parse('#002233');
+
+        // Oklab Euclidean picks the neutral grey, CIEDE2000 discounts the chroma difference and picks the navy.
+        $this->assertSame('#404040', $palette->closest($target)->toHex());
+        $this->assertSame('#00007f', $palette->closest($target, new Ciede2000())->toHex());
     }
 
     public function testClosestWithExactMatch(): void
@@ -206,6 +237,16 @@ final class ColorPaletteTest extends TestCase
         $closest = $palette->closest($target);
 
         $this->assertSame('#00ff00', $closest->toHex());
+    }
+
+    public function testClosestWithMetricAndSingleColor(): void
+    {
+        $palette = ColorPalette::fromHex(['#ff0000']);
+        $target = Color::parse('#0000ff');
+
+        $closest = $palette->closest($target, new Ciede2000());
+
+        $this->assertSame('#ff0000', $closest->toHex());
     }
 
     public function testClosestWithSingleColor(): void


### PR DESCRIPTION
`ColorPaletteInterface::closest()` documented CIEDE2000 while the implementation used Euclidean distance in Oklab.

Changes:
- `src/Palette/ColorPaletteInterface.php`: `closest()` takes an optional `?ColorDistanceInterface $metric`, docblock now states the real default.
- `src/Palette/ColorPalette.php`: use the given metric, or fall back to a private `oklabDistance()` holding the previous computation.

Default behaviour is unchanged, so existing call sites keep their results.

