### PR TITLE
[Docs] Document wide-gamut channel clamping

### DIFF
--- a/docs/core-concepts/color-spaces.md
+++ b/docs/core-concepts/color-spaces.md
@@ -36,6 +36,18 @@ Advanced spaces that can represent more vivid and saturated colors than standard
 | **Adobe RGB** | Developed for professional printing and photography (A98). | [Read more](./space/a98-rgb.md) |
 | **ProPhoto** | An extremely wide-gamut space covering 90%+ of visible colors. | [Read more](./space/prophoto-rgb.md) |
 
+These four constructors clamp each channel to `[0, 1]`:
+
+```php
+new DisplayP3Color(1.2, 0.0, 0.5);       // stored as 1.0, 0.0, 0.5
+Color::parse('color(display-p3 1.2 0 0.5)')->toCss();
+// color(display-p3 1 0 0.5)
+```
+
+CSS Color 4 allows coordinates outside `[0, 1]` in `color()`, and defers gamut mapping to the used value. A color parsed with out-of-range coordinates therefore does not round trip back to its original notation.
+
+`SrgbColor` and `XyzColor` do not clamp, so out-of-sRGB intermediate values survive a conversion chain.
+
 ## Other Spaces
 
 | Space | Description | Documentation |

--- a/src/A98RgbColor.php
+++ b/src/A98RgbColor.php
@@ -34,6 +34,9 @@ final readonly class A98RgbColor extends AbstractColor
 
     /**
      * Create a new A98-RGB color from red, green, blue, and alpha components.
+     *
+     * Each channel is clamped to [0, 1]. CSS Color 4 permits out-of-range coordinates in
+     * color(), so a color parsed with such coordinates does not round trip unchanged.
      */
     public function __construct(
         float $r,

--- a/src/DisplayP3Color.php
+++ b/src/DisplayP3Color.php
@@ -31,6 +31,9 @@ final readonly class DisplayP3Color extends AbstractColor
 
     /**
      * Create a new Display P3 color from red, green, blue, and alpha components.
+     *
+     * Each channel is clamped to [0, 1]. CSS Color 4 permits out-of-range coordinates in
+     * color(), so a color parsed with such coordinates does not round trip unchanged.
      */
     public function __construct(
         float $r,

--- a/src/ProPhotoColor.php
+++ b/src/ProPhotoColor.php
@@ -33,6 +33,9 @@ final readonly class ProPhotoColor extends AbstractColor
 
     /**
      * Create a new ProPhoto RGB color from red, green, blue, and alpha components.
+     *
+     * Each channel is clamped to [0, 1]. CSS Color 4 permits out-of-range coordinates in
+     * color(), so a color parsed with such coordinates does not round trip unchanged.
      */
     public function __construct(
         float $r,

--- a/src/Rec2020Color.php
+++ b/src/Rec2020Color.php
@@ -35,6 +35,9 @@ final readonly class Rec2020Color extends AbstractColor
 
     /**
      * Create a new Rec.2020 color from red, green, blue, and alpha components.
+     *
+     * Each channel is clamped to [0, 1]. CSS Color 4 permits out-of-range coordinates in
+     * color(), so a color parsed with such coordinates does not round trip unchanged.
      */
     public function __construct(
         float $r,


### PR DESCRIPTION
The wide-gamut constructors clamp channels to `[0, 1]`, which was documented nowhere.

Changes:
- `src/DisplayP3Color.php`, `A98RgbColor.php`, `ProPhotoColor.php`, `Rec2020Color.php`: state the clamping in the constructor docblock.

(Documentation only, no behaviour change)
