### PR TITLE
[Fix] Interpolate colors with premultiplied alpha

### DIFF
--- a/src/Color.php
+++ b/src/Color.php
@@ -140,7 +140,9 @@ final class Color
     /**
      * Mix two colors together in a specified color space.
      *
-     * Supports mixing in sRGB (linear) and Oklab spaces.
+     * Supports mixing in sRGB (linear) and Oklab spaces. Color channels are interpolated with
+     * premultiplied alpha, as specified by CSS Color 4, so a transparent endpoint does not tint
+     * the result.
      *
      * @throws InvalidColorException
      */
@@ -167,16 +169,11 @@ final class Color
                 self::srgbToLinear($rb->b),
             ];
 
-            $lr = [
-                self::lerp($la[0], $lb[0], $t),
-                self::lerp($la[1], $lb[1], $t),
-                self::lerp($la[2], $lb[2], $t),
-            ];
+            [$lr0, $lr1, $lr2, $a2] = self::lerpPremultiplied($la, $ra->a, $lb, $rb->a, $t);
 
-            $r = self::linearToSrgb($lr[0]);
-            $g = self::linearToSrgb($lr[1]);
-            $b2 = self::linearToSrgb($lr[2]);
-            $a2 = self::lerp($ra->a, $rb->a, $t);
+            $r = self::linearToSrgb($lr0);
+            $g = self::linearToSrgb($lr1);
+            $b2 = self::linearToSrgb($lr2);
 
             return new SrgbColor($r, $g, $b2, $a2);
         }
@@ -188,10 +185,13 @@ final class Color
             $ra = $oa instanceof OklabColor ? $oa : OklabColor::fromSrgb($oa->toSrgb());
             $rb = $ob instanceof OklabColor ? $ob : OklabColor::fromSrgb($ob->toSrgb());
 
-            $l = self::lerp($ra->l, $rb->l, $t);
-            $aVal = self::lerp($ra->a, $rb->a, $t);
-            $bVal = self::lerp($ra->b, $rb->b, $t);
-            $alpha = self::lerp($ra->alpha, $rb->alpha, $t);
+            [$l, $aVal, $bVal, $alpha] = self::lerpPremultiplied(
+                [$ra->l, $ra->a, $ra->b],
+                $ra->alpha,
+                [$rb->l, $rb->a, $rb->b],
+                $rb->alpha,
+                $t,
+            );
 
             return new OklabColor($l, $aVal, $bVal, $alpha);
         }
@@ -331,6 +331,39 @@ final class Color
     private static function lerp(float $a, float $b, float $t): float
     {
         return $a + ($b - $a) * $t;
+    }
+
+    /**
+     * Interpolate three color channels and alpha using premultiplied alpha.
+     *
+     * Each channel is weighted by its own alpha before interpolation, then divided by the
+     * interpolated alpha. When that alpha is zero the un-premultiplied channels are undefined
+     * per CSS Color 4, so the plain channel interpolation is returned instead.
+     *
+     * @param array{float, float, float} $ca
+     * @param array{float, float, float} $cb
+     *
+     * @return array{float, float, float, float} The interpolated channels followed by alpha
+     */
+    private static function lerpPremultiplied(array $ca, float $aa, array $cb, float $ab, float $t): array
+    {
+        $alpha = self::lerp($aa, $ab, $t);
+
+        if (0.0 >= $alpha) {
+            return [
+                self::lerp($ca[0], $cb[0], $t),
+                self::lerp($ca[1], $cb[1], $t),
+                self::lerp($ca[2], $cb[2], $t),
+                $alpha,
+            ];
+        }
+
+        return [
+            self::lerp($ca[0] * $aa, $cb[0] * $ab, $t) / $alpha,
+            self::lerp($ca[1] * $aa, $cb[1] * $ab, $t) / $alpha,
+            self::lerp($ca[2] * $aa, $cb[2] * $ab, $t) / $alpha,
+            $alpha,
+        ];
     }
 
     private static function linearToSrgb(float $c): float

--- a/tests/ColorTest.php
+++ b/tests/ColorTest.php
@@ -567,6 +567,26 @@ final class ColorTest extends TestCase
         $this->assertEqualsWithDelta(1.0, $ratio, 0.01);
     }
 
+    public function testMixWithBothEndpointsTransparent(): void
+    {
+        $red = Color::parse('rgb(255 0 0 / 0)');
+        $blue = Color::parse('rgb(0 0 255 / 0)');
+
+        // A zero interpolated alpha leaves the channels undefined per CSS Color 4; this library
+        // falls back to plain interpolation, the limit of the premultiplied formula.
+        $oklab = Color::mix($red, $blue, 0.5, 'oklab');
+        $this->assertInstanceOf(OklabColor::class, $oklab);
+        $this->assertSame(0.0, $oklab->alpha);
+        $this->assertEqualsWithDelta(0.539984539499947, $oklab->l, 1e-12);
+        $this->assertEqualsWithDelta(0.096203038448605, $oklab->a, 1e-12);
+        $this->assertEqualsWithDelta(-0.092840924573820, $oklab->b, 1e-12);
+
+        $srgb = Color::mix($red, $blue, 0.5, 'srgb');
+        $this->assertInstanceOf(SrgbColor::class, $srgb);
+        $this->assertSame(0.0, $srgb->a);
+        $this->assertSame('#bc00bc', $srgb->toHex());
+    }
+
     public function testMixWithColorInterfaceSpace(): void
     {
         $red = Color::parse('#ff0000');
@@ -602,6 +622,45 @@ final class ColorTest extends TestCase
         $this->assertEqualsWithDelta(1.0, $srgb->b, 0.01);
     }
 
+    public function testMixWithOneTPreservesAlpha(): void
+    {
+        $red = Color::parse('rgb(255 0 0 / 0.8)');
+        $blue = Color::parse('rgb(0 0 255 / 0.2)');
+
+        // lerp() is not bit-exact at t=1, so alpha lands one ulp below 0.2 here.
+        $oklab = Color::mix($red, $blue, 1.0, 'oklab');
+        $this->assertInstanceOf(OklabColor::class, $oklab);
+        $this->assertEqualsWithDelta(0.2, $oklab->alpha, 1e-12);
+        $this->assertSame('#0000ff', $oklab->toSrgb()->toHex());
+
+        $srgb = Color::mix($red, $blue, 1.0, 'srgb');
+        $this->assertInstanceOf(SrgbColor::class, $srgb);
+        $this->assertEqualsWithDelta(0.2, $srgb->a, 1e-12);
+        $this->assertSame('#0000ff', $srgb->toHex());
+    }
+
+    public function testMixWithOpaqueEndpoints(): void
+    {
+        $red = Color::parse('rgb(255 0 0)');
+        $blue = Color::parse('rgb(0 0 255)');
+
+        $oklab = Color::mix($red, $blue, 0.5, 'oklab');
+        $this->assertInstanceOf(OklabColor::class, $oklab);
+        $this->assertSame(1.0, $oklab->alpha);
+        $this->assertEqualsWithDelta(0.539984539499947, $oklab->l, 1e-12);
+        $this->assertEqualsWithDelta(0.096203038448605, $oklab->a, 1e-12);
+        $this->assertEqualsWithDelta(-0.092840924573820, $oklab->b, 1e-12);
+        $this->assertSame('#8c53a2', $oklab->toSrgb()->toHex());
+
+        $srgb = Color::mix($red, $blue, 0.5, 'srgb');
+        $this->assertInstanceOf(SrgbColor::class, $srgb);
+        $this->assertSame(1.0, $srgb->a);
+        $this->assertEqualsWithDelta(0.735356983052449, $srgb->r, 1e-12);
+        $this->assertEqualsWithDelta(0.0, $srgb->g, 1e-12);
+        $this->assertEqualsWithDelta(0.735356983052449, $srgb->b, 1e-12);
+        $this->assertSame('#bc00bc', $srgb->toHex());
+    }
+
     public function testMixWithOverflowT(): void
     {
         $red = Color::parse('#ff0000');
@@ -611,6 +670,52 @@ final class ColorTest extends TestCase
         // t > 1 should clamp to 1
         $srgb = $result->toSrgb();
         $this->assertEqualsWithDelta(1.0, $srgb->b, 0.01);
+    }
+
+    public function testMixWithPartialAlphaOklab(): void
+    {
+        $red = Color::parse('rgb(255 0 0 / 0.8)');
+        $blue = Color::parse('rgb(0 0 255 / 0.2)');
+
+        $mixed = Color::mix($red, $blue, 0.5, 'oklab');
+
+        $this->assertInstanceOf(OklabColor::class, $mixed);
+        $this->assertSame(0.5, $mixed->alpha);
+        // Equal weights premultiplied reduce to the alpha-weighted average 0.8 * red + 0.2 * blue.
+        $this->assertEqualsWithDelta(0.592767032168710, $mixed->l, 1e-12);
+        $this->assertEqualsWithDelta(0.173399052019026, $mixed->a, 1e-12);
+        $this->assertEqualsWithDelta(0.038371409288913, $mixed->b, 1e-12);
+    }
+
+    public function testMixWithPartialAlphaSrgb(): void
+    {
+        $red = Color::parse('rgb(255 0 0 / 0.8)');
+        $blue = Color::parse('rgb(0 0 255 / 0.2)');
+
+        $mixed = Color::mix($red, $blue, 0.5, 'srgb');
+
+        $this->assertInstanceOf(SrgbColor::class, $mixed);
+        $this->assertSame(0.5, $mixed->a);
+        $this->assertEqualsWithDelta(0.906331753344059, $mixed->r, 1e-12);
+        $this->assertEqualsWithDelta(0.0, $mixed->g, 1e-12);
+        $this->assertEqualsWithDelta(0.484529204481707, $mixed->b, 1e-12);
+        $this->assertSame('#e7007c', $mixed->toHex());
+    }
+
+    public function testMixWithTransparentEndpointPreservesHue(): void
+    {
+        $red = Color::parse('rgb(255 0 0 / 1)');
+        $blue = Color::parse('rgb(0 0 255 / 0)');
+
+        $oklab = Color::mix($red, $blue, 0.5, 'oklab');
+        $this->assertInstanceOf(OklabColor::class, $oklab);
+        $this->assertSame(0.5, $oklab->alpha);
+        $this->assertSame('#ff0000', $oklab->toSrgb()->toHex());
+
+        $srgb = Color::mix($red, $blue, 0.5, 'srgb');
+        $this->assertInstanceOf(SrgbColor::class, $srgb);
+        $this->assertSame(0.5, $srgb->a);
+        $this->assertSame('#ff0000', $srgb->toHex());
     }
 
     public function testMixWithZeroT(): void
@@ -623,6 +728,22 @@ final class ColorTest extends TestCase
         $srgb = $result->toSrgb();
         $this->assertEqualsWithDelta(1.0, $srgb->r, 0.01);
         $this->assertEqualsWithDelta(0.0, $srgb->b, 0.01);
+    }
+
+    public function testMixWithZeroTPreservesAlpha(): void
+    {
+        $red = Color::parse('rgb(255 0 0 / 0.8)');
+        $blue = Color::parse('rgb(0 0 255 / 0.2)');
+
+        $oklab = Color::mix($red, $blue, 0.0, 'oklab');
+        $this->assertInstanceOf(OklabColor::class, $oklab);
+        $this->assertSame(0.8, $oklab->alpha);
+        $this->assertSame('#ff0000', $oklab->toSrgb()->toHex());
+
+        $srgb = Color::mix($red, $blue, 0.0, 'srgb');
+        $this->assertInstanceOf(SrgbColor::class, $srgb);
+        $this->assertSame(0.8, $srgb->a);
+        $this->assertSame('#ff0000', $srgb->toHex());
     }
 
     public function testParseColorFunctionEmptyParams(): void


### PR DESCRIPTION
`Color::mix()` interpolated alpha independently, so a fully transparent endpoint still tinted the result.

Changes
- `src/Color.php`: both the `srgb` and `oklab` branches weight each channel by its own alpha before interpolating, then divide by the interpolated alpha.

Mixing opaque red with fully transparent blue returned `#8c53a2`, a purple. It now returns `#ff0000` at alpha 0.5.

Opaque mixes are bit-identical to before, so `shade()`, `tint()` and gradients of opaque colors are untouched. 
