### PR TITLE
[Fix] Compute Lab and LCH against D50

### DIFF
--- a/src/Colorimetry/ReferenceWhite.php
+++ b/src/Colorimetry/ReferenceWhite.php
@@ -27,6 +27,7 @@ final class ReferenceWhite
      * - Rec.2020: 'rec2020', 'rec-2020', 'bt2020', 'bt-2020'
      * - A98 RGB: 'a98-rgb', 'a98', 'adobe-rgb'
      * - ProPhoto RGB: 'prophoto-rgb', 'prophoto', 'romm-rgb'
+     * - CIELAB family: 'lab', 'lch'
      */
     public static function forSpace(string $space): WhitePoint
     {
@@ -45,6 +46,7 @@ final class ReferenceWhite
 
         $d50 = [
             'prophoto-rgb', 'prophoto', 'romm-rgb',
+            'lab', 'lch',
         ];
 
         if (\in_array($s, $d50, true)) {

--- a/src/LabColor.php
+++ b/src/LabColor.php
@@ -21,7 +21,8 @@ use PhpColor\Color\Exception\ParseException;
  *
  * CIELAB (or Lab) is a device-independent color space that covers the entire
  * range of human color perception. Components are lightness (L), and two
- * color-opponent dimensions (a and b).
+ * color-opponent dimensions (a and b). As specified by CSS Color 4 and ICC,
+ * it uses a D50 white point, so the D65 pipeline is adapted with Bradford.
  */
 final readonly class LabColor extends AbstractColor
 {
@@ -67,13 +68,16 @@ final readonly class LabColor extends AbstractColor
      */
     public static function fromXyz(XyzColor $xyz): static
     {
-        $xn = 0.95047;
-        $yn = 1.0;
-        $zn = 1.08883;
+        $white = Colorimetry\ReferenceWhite::forSpace('lab');
+        $adapted = Colorimetry\Adaptation\Bradford::adaptXYZ(
+            [$xyz->x, $xyz->y, $xyz->z],
+            Colorimetry\Illuminant::D65->whitePoint(),
+            $white
+        );
 
-        $x = $xyz->x / $xn;
-        $y = $xyz->y / $yn;
-        $z = $xyz->z / $zn;
+        $x = $adapted[0] / $white->X;
+        $y = $adapted[1] / $white->Y;
+        $z = $adapted[2] / $white->Z;
 
         $epsilon = 0.008856;
         $kappa = 903.3;
@@ -192,9 +196,7 @@ final readonly class LabColor extends AbstractColor
      */
     public function toXyz(): XyzColor
     {
-        $xn = 0.95047;
-        $yn = 1.0;
-        $zn = 1.08883;
+        $white = Colorimetry\ReferenceWhite::forSpace('lab');
 
         $fy = ($this->l + 16.0) / 116.0;
         $fx = $this->a / 500.0 + $fy;
@@ -210,10 +212,12 @@ final readonly class LabColor extends AbstractColor
         $y = ($this->l > $kappa * $epsilon) ? (($this->l + 16.0) / 116.0) ** 3.0 : $this->l / $kappa;
         $z = ($fz3 > $epsilon) ? $fz3 : (116.0 * $fz - 16.0) / $kappa;
 
-        $x *= $xn;
-        $y *= $yn;
-        $z *= $zn;
+        $adapted = Colorimetry\Adaptation\Bradford::adaptXYZ(
+            [$x * $white->X, $y * $white->Y, $z * $white->Z],
+            $white,
+            Colorimetry\Illuminant::D65->whitePoint()
+        );
 
-        return new XyzColor($x, $y, $z, $this->alpha);
+        return new XyzColor($adapted[0], $adapted[1], $adapted[2], $this->alpha);
     }
 }

--- a/tests/LabColorTest.php
+++ b/tests/LabColorTest.php
@@ -38,16 +38,16 @@ final class LabColorTest extends ColorTestCase
     {
         // color, hex, hexWithAlpha, css
         yield 'red' => [
-            new LabColor(53.24, 80.09, 67.2), // sRGB Red
+            new LabColor(54.29, 80.8, 69.89), // sRGB Red
             '#ff0000',
             '#ff0000ff',
-            'lab(53.24 80.09 67.2)',
+            'lab(54.29 80.8 69.89)',
         ];
         yield 'translucent blue' => [
-            new LabColor(32.3, 79.19, -107.86, 0.5), // sRGB Blue
+            new LabColor(29.57, 68.29, -112.03, 0.5), // sRGB Blue
             '#0000ff',
             '#0000ff80',
-            'lab(32.3 79.19 -107.86 / 0.5)',
+            'lab(29.57 68.29 -112.03 / 0.5)',
         ];
     }
 
@@ -148,6 +148,84 @@ final class LabColorTest extends ColorTestCase
 
         $lab2 = new LabColor(150.0, 0.0, 0.0);
         $this->assertSame(100.0, $lab2->l);
+    }
+
+    #[DataProvider('provideCssColor4ReferenceValues')]
+    public function testMatchesCssColor4ReferenceValues(string $hex, float $l, float $a, float $b): void
+    {
+        $lab = LabColor::fromSrgb(SrgbColor::parseHex($hex));
+
+        $this->assertEqualsWithDelta($l, $lab->l, 0.05);
+        $this->assertEqualsWithDelta($a, $lab->a, 0.05);
+        $this->assertEqualsWithDelta($b, $lab->b, 0.05);
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: float, 2: float, 3: float}>
+     */
+    public static function provideCssColor4ReferenceValues(): iterable
+    {
+        // lab() coordinates per CSS Color 4, which defines Lab against the D50 reference white.
+        yield 'red' => ['#ff0000', 54.290541, 80.804928, 69.890965];
+        yield 'green' => ['#00ff00', 87.818534, -79.271061, 80.994581];
+        yield 'blue' => ['#0000ff', 29.568302, 68.287365, -112.029710];
+        yield 'white' => ['#ffffff', 100.0, 0.0, 0.0];
+        yield 'black' => ['#000000', 0.0, 0.0, 0.0];
+        yield 'mid gray' => ['#808080', 53.585013, 0.0, 0.0];
+        yield 'steel blue' => ['#336699', 41.520824, -4.573090, -33.494195];
+        yield 'olive' => ['#7f7f00', 51.765383, -9.394607, 55.708293];
+    }
+
+    #[DataProvider('provideNeutrals')]
+    public function testNeutralsAreAchromatic(string $hex, float $l): void
+    {
+        $lab = LabColor::fromSrgb(SrgbColor::parseHex($hex));
+
+        $this->assertEqualsWithDelta($l, $lab->l, 0.001);
+        $this->assertEqualsWithDelta(0.0, $lab->a, 0.001);
+        $this->assertEqualsWithDelta(0.0, $lab->b, 0.001);
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: float}>
+     */
+    public static function provideNeutrals(): iterable
+    {
+        yield 'white' => ['#ffffff', 100.0];
+        yield 'black' => ['#000000', 0.0];
+        yield 'mid gray' => ['#808080', 53.585013];
+        yield 'light gray' => ['#cccccc', 82.045782];
+        yield 'dark gray' => ['#333333', 21.246731];
+    }
+
+    #[DataProvider('provideRoundTripHexColors')]
+    public function testRoundTripFromSrgb(string $hex): void
+    {
+        $srgb = SrgbColor::parseHex($hex);
+        $back = LabColor::fromSrgb($srgb)->toSrgb();
+
+        $this->assertEqualsWithDelta($srgb->r, $back->r, 0.001);
+        $this->assertEqualsWithDelta($srgb->g, $back->g, 0.001);
+        $this->assertEqualsWithDelta($srgb->b, $back->b, 0.001);
+    }
+
+    /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function provideRoundTripHexColors(): iterable
+    {
+        yield 'red' => ['#ff0000'];
+        yield 'green' => ['#00ff00'];
+        yield 'blue' => ['#0000ff'];
+        yield 'cyan' => ['#00ffff'];
+        yield 'magenta' => ['#ff00ff'];
+        yield 'yellow' => ['#ffff00'];
+        yield 'white' => ['#ffffff'];
+        yield 'black' => ['#000000'];
+        yield 'mid gray' => ['#808080'];
+        yield 'steel blue' => ['#336699'];
+        yield 'olive' => ['#7f7f00'];
+        yield 'salmon' => ['#fa8072'];
     }
 
     #[DataProvider('provideParseCases')]

--- a/tests/LchColorTest.php
+++ b/tests/LchColorTest.php
@@ -38,16 +38,16 @@ final class LchColorTest extends ColorTestCase
     {
         // color, hex, hexWithAlpha, css
         yield 'red' => [
-            new LchColor(53.24, 104.55, 40.0),
+            new LchColor(54.29, 106.84, 40.86),
             '#ff0000',
             '#ff0000ff',
-            'lch(53.24 104.55 40)',
+            'lch(54.29 106.84 40.86)',
         ];
         yield 'translucent blue' => [
-            new LchColor(32.3, 133.81, 306.28, 0.5),
+            new LchColor(29.57, 131.2, 301.36, 0.5),
             '#0000ff',
             '#0000ff80',
-            'lch(32.3 133.81 306.28 / 0.5)',
+            'lch(29.57 131.2 301.36 / 0.5)',
         ];
     }
 
@@ -184,6 +184,78 @@ final class LchColorTest extends ColorTestCase
 
         $lch2 = new LchColor(150.0, 0.0, 0.0);
         $this->assertSame(100.0, $lch2->l);
+    }
+
+    #[DataProvider('provideCssColor4ReferenceValues')]
+    public function testMatchesCssColor4ReferenceValues(string $hex, float $l, float $c, float $h): void
+    {
+        $lch = LchColor::fromSrgb(SrgbColor::parseHex($hex));
+
+        $this->assertEqualsWithDelta($l, $lch->l, 0.05);
+        $this->assertEqualsWithDelta($c, $lch->c, 0.05);
+        $this->assertEqualsWithDelta($h, $lch->h, 0.05);
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: float, 2: float, 3: float}>
+     */
+    public static function provideCssColor4ReferenceValues(): iterable
+    {
+        // lch() coordinates per CSS Color 4, which defines LCH against the D50 reference white.
+        yield 'red' => ['#ff0000', 54.290541, 106.837182, 40.857657];
+        yield 'green' => ['#00ff00', 87.818534, 113.331475, 134.383856];
+        yield 'blue' => ['#0000ff', 29.568302, 131.201448, 301.364268];
+        yield 'steel blue' => ['#336699', 41.520824, 33.804944, 262.225262];
+        yield 'olive' => ['#7f7f00', 51.765383, 56.494889, 99.572255];
+    }
+
+    #[DataProvider('provideNeutrals')]
+    public function testNeutralsHaveZeroChroma(string $hex, float $l): void
+    {
+        $lch = LchColor::fromSrgb(SrgbColor::parseHex($hex));
+
+        $this->assertEqualsWithDelta($l, $lch->l, 0.001);
+        $this->assertEqualsWithDelta(0.0, $lch->c, 0.001);
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: float}>
+     */
+    public static function provideNeutrals(): iterable
+    {
+        yield 'white' => ['#ffffff', 100.0];
+        yield 'black' => ['#000000', 0.0];
+        yield 'mid gray' => ['#808080', 53.585013];
+    }
+
+    #[DataProvider('provideRoundTripHexColors')]
+    public function testRoundTripFromSrgb(string $hex): void
+    {
+        $srgb = SrgbColor::parseHex($hex);
+        $back = LchColor::fromSrgb($srgb)->toSrgb();
+
+        $this->assertEqualsWithDelta($srgb->r, $back->r, 0.001);
+        $this->assertEqualsWithDelta($srgb->g, $back->g, 0.001);
+        $this->assertEqualsWithDelta($srgb->b, $back->b, 0.001);
+    }
+
+    /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function provideRoundTripHexColors(): iterable
+    {
+        yield 'red' => ['#ff0000'];
+        yield 'green' => ['#00ff00'];
+        yield 'blue' => ['#0000ff'];
+        yield 'cyan' => ['#00ffff'];
+        yield 'magenta' => ['#ff00ff'];
+        yield 'yellow' => ['#ffff00'];
+        yield 'white' => ['#ffffff'];
+        yield 'black' => ['#000000'];
+        yield 'mid gray' => ['#808080'];
+        yield 'steel blue' => ['#336699'];
+        yield 'olive' => ['#7f7f00'];
+        yield 'salmon' => ['#fa8072'];
     }
 
     #[DataProvider('provideParseCases')]


### PR DESCRIPTION
`LabColor` hardcoded a D65 reference white, while CSS Color 4 and ICC define `lab()` and `lch()` against D50.

Changes:

- `src/LabColor.php`: `fromXyz()` and `toXyz()` adapt between D65 and D50 with Bradford, and read the white point from `ReferenceWhite` instead of hardcoded constants.
- `src/Colorimetry/ReferenceWhite.php`: register `lab` and `lch` as D50 spaces; they fell through to the D65 default.
