### PR TITLE
[Docs] Replace the universal distance threshold table

### DIFF
--- a/docs/reference/distance.md
+++ b/docs/reference/distance.md
@@ -33,13 +33,33 @@ $d = Color::distance($c1, $c2, 'CMC(2:1)');
 ```
 
 ### Interpretation
+
+The values below are the usual reference points for CIEDE2000 on small color patches.
+
 | Delta E | Perception |
 | :--- | :--- |
 | **< 1.0** | Not perceptible by human eyes |
 | **1.0 – 2.0** | Perceptible through close observation |
 | **2.0 – 10.0** | Perceptible at a glance |
-| **11.0 – 49.0** | Colors are more similar than opposite |
-| **100.0** | Colors are exact opposites |
+| **> 10.0** | Clearly different colors |
+
+There is no universal upper bound, and no value means "opposite". Black against white
+scores exactly 100 in CIEDE2000, but that is the length of the lightness axis, not a maximum:
+green against magenta reaches 108.6.
+
+The scale also depends on the algorithm. The same black and white pair scores 100 in DeltaE94
+and 97.9 in CMC. The values below compare every pair among the eight corners of the sRGB cube:
+black, white, red, green, blue, cyan, magenta, and yellow. They are sample maxima, not universal
+upper bounds.
+
+| Algorithm | Black vs white | Largest among sRGB cube corners |
+| :--- | ---: | ---: |
+| CIEDE2000 | 100.0 | 108.6 |
+| DeltaE94 | 100.0 | 148.9 |
+| CMC(2:1) | 97.9 | 207.7 |
+
+Calibrate your own thresholds against samples from your project rather than reusing a fixed
+table, especially when comparing large areas, text, or colors seen under different lighting.
 
 ## Examples
 


### PR DESCRIPTION
# [Docs] Replace the universal distance threshold table

Branch: `docs/distance-thresholds` onto `main` | Workspace: `dev/audit-fixes`

The distance reference claimed `100.0` means "exact opposites", which is not a bound of any Delta E algorithm.

## Changes

- `docs/reference/distance.md`: drop the two unfounded rows, state that the scale is algorithm-dependent, and add the measured figures.

## Notes

- Black against white scores exactly 100 in CIEDE2000, which is where the claim came from, but that is the lightness axis, not a maximum: green against magenta reaches 108.6.
- The same pair scores 100 in DeltaE94 and 97.9 in CMC, and their largest measured distances are 148.9 and 207.7.
- The first three rows are kept: they are the usual CIEDE2000 reference points and are not in question.
- Readers are pointed at calibrating thresholds on their own samples.
