### PR TITLE
[Fix] Rename toHsl() to getHslChannels()

### DIFF
--- a/src/AbstractColor.php
+++ b/src/AbstractColor.php
@@ -356,6 +356,10 @@ abstract readonly class AbstractColor implements \Stringable, ColorInterface
             'cmyk' => CmykColor::class,
         ];
 
+        if ('hsl' === $target) {
+            throw new InvalidColorException('"hsl" is an sRGB notation, not a color space. Use toSrgb()->toCss(\'hsl\') to serialize it, or toSrgb()->getHslChannels() to read its channels.');
+        }
+
         if (!isset($spaceMap[$target])) {
             throw new InvalidColorException(\sprintf('Unknown or unsupported color space "%s".', $space));
         }

--- a/src/Css/CssColorParser.php
+++ b/src/Css/CssColorParser.php
@@ -248,7 +248,7 @@ final class CssColorParser
 
         if ('hsl' === $targetSpace) {
             $srgb = $origin->toSrgb();
-            $hsl = $srgb->toHsl();
+            $hsl = $srgb->getHslChannels();
 
             return [
                 ['h' => $hsl['h'], 's' => $hsl['s'], 'l' => $hsl['l']],

--- a/src/SrgbColor.php
+++ b/src/SrgbColor.php
@@ -238,7 +238,7 @@ final readonly class SrgbColor extends AbstractColor
         }
 
         if ('hsl' === $target) {
-            $hsl = $this->toHsl();
+            $hsl = $this->getHslChannels();
             $h = self::formatCssFloat($hsl['h']);
             $s = self::formatCssFloat($hsl['s'] * 100.0);
             $l = self::formatCssFloat($hsl['l'] * 100.0);
@@ -282,11 +282,14 @@ final readonly class SrgbColor extends AbstractColor
     }
 
     /**
-     * Convert the color to its HSL representation.
+     * Read the color as HSL channels.
+     *
+     * HSL is a cylindrical notation of sRGB, not a separate color space, so this
+     * returns channel values rather than a color object.
      *
      * @return array{h: float, s: float, l: float}
      */
-    public function toHsl(): array
+    public function getHslChannels(): array
     {
         $r = $this->r;
         $g = $this->g;
@@ -316,6 +319,18 @@ final readonly class SrgbColor extends AbstractColor
         }
 
         return ['h' => $h, 's' => $s, 'l' => $l];
+    }
+
+    /**
+     * Read the color as HSL channels.
+     *
+     * @return array{h: float, s: float, l: float}
+     *
+     * @deprecated since 1.1, use getHslChannels() instead
+     */
+    public function toHsl(): array
+    {
+        return $this->getHslChannels();
     }
 
     public function toSrgb(): self

--- a/tests/AbstractColorTest.php
+++ b/tests/AbstractColorTest.php
@@ -248,6 +248,22 @@ final class AbstractColorTest extends TestCase
         $this->assertEqualsWithDelta(0.8, $changed->getAlpha(), 1e-12);
     }
 
+    public function testToHslExplainsItIsANotation(): void
+    {
+        $this->expectException(InvalidColorException::class);
+        $this->expectExceptionMessage('"hsl" is an sRGB notation, not a color space.');
+
+        Color::parse('#ff0000')->to('hsl');
+    }
+
+    public function testToHslSuggestsRoutesThatWorkFromAnySpace(): void
+    {
+        $color = Color::parse('oklch(0.7 0.15 250)');
+
+        $this->assertStringStartsWith('hsl(', $color->toSrgb()->toCss('hsl'));
+        $this->assertArrayHasKey('s', $color->toSrgb()->getHslChannels());
+    }
+
     public function testToOklchMatchesToWithSpaceName(): void
     {
         foreach (['#3b82f6', '#000000', '#ffffff', '#808080'] as $hex) {

--- a/tests/SrgbColorTest.php
+++ b/tests/SrgbColorTest.php
@@ -236,7 +236,7 @@ final class SrgbColorTest extends ColorTestCase
 
         $this->assertInstanceOf(SrgbColor::class, $srgb);
 
-        $hsl = $srgb->toHsl();
+        $hsl = $srgb->getHslChannels();
         $this->assertIsArray($hsl);
         $this->assertArrayHasKey('h', $hsl);
         $this->assertArrayHasKey('s', $hsl);
@@ -383,11 +383,18 @@ final class SrgbColorTest extends ColorTestCase
         $srgb->toCss('unsupported-space');
     }
 
+    public function testToHslIsAnAliasOfGetHslChannels(): void
+    {
+        $color = new SrgbColor(0.2, 0.6, 0.9);
+
+        $this->assertSame($color->getHslChannels(), $color->toHsl());
+    }
+
     public function testToHslGrayscale(): void
     {
         // When R=G=B, should return zero saturation
         $gray = new SrgbColor(0.5, 0.5, 0.5);
-        $hsl = $gray->toHsl();
+        $hsl = $gray->getHslChannels();
         $this->assertSame(0.0, $hsl['h']);
         $this->assertSame(0.0, $hsl['s']);
         $this->assertSame(0.5, $hsl['l']);
@@ -397,7 +404,7 @@ final class SrgbColorTest extends ColorTestCase
     {
         // Test saturation calculation when lightness > 0.5
         $color = new SrgbColor(0.9, 0.7, 0.8);
-        $hsl = $color->toHsl();
+        $hsl = $color->getHslChannels();
         $this->assertGreaterThan(0.0, $hsl['s']);
         $this->assertGreaterThan(0.5, $hsl['l']);
     }
@@ -406,7 +413,7 @@ final class SrgbColorTest extends ColorTestCase
     {
         // Test case where hue calculation might be negative
         $color = new SrgbColor(0.9, 0.2, 0.8);
-        $hsl = $color->toHsl();
+        $hsl = $color->getHslChannels();
         $this->assertGreaterThanOrEqual(0.0, $hsl['h']);
         $this->assertLessThan(360.0, $hsl['h']);
     }
@@ -415,7 +422,7 @@ final class SrgbColorTest extends ColorTestCase
     {
         // Test when blue is the maximum component
         $color = new SrgbColor(0.2, 0.3, 0.9);
-        $hsl = $color->toHsl();
+        $hsl = $color->getHslChannels();
         $this->assertIsFloat($hsl['h']);
         $this->assertIsFloat($hsl['s']);
         $this->assertIsFloat($hsl['l']);
@@ -427,7 +434,7 @@ final class SrgbColorTest extends ColorTestCase
     {
         // Test when green is the maximum component
         $color = new SrgbColor(0.2, 0.8, 0.3);
-        $hsl = $color->toHsl();
+        $hsl = $color->getHslChannels();
         $this->assertIsFloat($hsl['h']);
         $this->assertIsFloat($hsl['s']);
         $this->assertIsFloat($hsl['l']);


### PR DESCRIPTION
# [Fix] Rename toHsl() to getHslChannels()

Branch: `fix/hsl-channels-naming` onto `main` | Workspace: `dev/audit-fixes`

`toHsl()` was the only `toXxx()` method returning an array instead of a color object.

## Changes

- `src/SrgbColor.php`: `toHsl()` becomes `getHslChannels()`, with `toHsl()` kept as a deprecated alias.
- `src/AbstractColor.php`: `to('hsl')` now explains that HSL is an sRGB notation and points to the two working alternatives.

## Notes

- The library already has two clear conventions: `toXxx()` converts and returns an object, `getChannels()` reads coordinates and returns an array. HSL belongs to the second.
- Returning an array is correct here: HSL is a cylindrical notation of sRGB, so there is nothing to convert, only the same color read differently.
- No `HslColor` class: it would assert a color space that does not exist. HSL shares sRGB's primaries, white point and gamut.
- `to('hsl')` previously said `Unknown or unsupported color space "hsl"`, which used the wrong term and offered no way forward. It now names `toCss('hsl')` and `getHslChannels()`.
- `fromHsl()` and `parseHsl()` are unchanged: their names are accurate.
